### PR TITLE
Fix ARM64 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,41 @@
-FROM metabase/metabase:v0.44.6
+#
+# Once https://github.com/metabase/metabase/issues/13119 will be resolved, please uncomment this
+# section to use the official image and remove everything after it.
+#
+# FROM metabase/metabase:v0.44.6
+#
+# ADD https://github.com/enqueue/metabase-clickhouse-driver/releases/download/0.7.5/clickhouse.metabase-driver.jar /plugins/
+#
+# RUN chmod 744 /plugins/clickhouse.metabase-driver.jar
+#
 
+FROM ubuntu:22.04
+
+ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+
+# Install dependencies
+RUN apt-get update -yq && apt-get install -yq bash fonts-dejavu-core fonts-dejavu-extra fontconfig curl openjdk-11-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/ && \
+    mkdir -p /app/certs && \
+    curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
+    keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
+    curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /app/certs/DigiCertGlobalRootG2.crt.pem  && \
+    keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
+    mkdir -p /plugins && chmod a+rwx /plugins && \
+    useradd --shell /bin/bash metabase
+
+WORKDIR /app
+
+# Copy the Metabase app from the offical image
+COPY --from=metabase/metabase:v0.44.6 /app /app
+RUN chown -R metabase /app
+
+# Copy the ClickHouse driver
 ADD https://github.com/enqueue/metabase-clickhouse-driver/releases/download/0.7.5/clickhouse.metabase-driver.jar /plugins/
-
 RUN chmod 744 /plugins/clickhouse.metabase-driver.jar
+
+USER metabase
+EXPOSE 3000
+
+ENTRYPOINT ["/app/run_metabase.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,11 @@ WORKDIR /app
 
 # Copy the Metabase app from the offical image
 COPY --from=metabase/metabase:v0.44.6 /app /app
-RUN chown -R metabase /app
 
 # Copy the ClickHouse driver
-ADD https://github.com/enqueue/metabase-clickhouse-driver/releases/download/0.7.5/clickhouse.metabase-driver.jar /plugins/
-RUN chmod 744 /plugins/clickhouse.metabase-driver.jar
+ADD --chmod=744 https://github.com/enqueue/metabase-clickhouse-driver/releases/download/0.7.5/clickhouse.metabase-driver.jar /app/plugins/
+
+RUN chown -R metabase /app
 
 USER metabase
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # metabase-clickhouse
 
-This repo builds the [official Metabase docker image](https://hub.docker.com/r/metabase/metabase/), with the addition of the [Clickhouse driver](https://github.com/enqueue/metabase-clickhouse-driver).
+This repo builds the [official Metabase docker image](https://hub.docker.com/r/metabase/metabase/), with the addition of the [Clickhouse driver](https://github.com/enqueue/metabase-clickhouse-driver) and ARM64 support (see upstream [issue](https://github.com/metabase/metabase/issues/13119)).
 
 To update the version of Metabase, update the Dockerfile and push a new tag to the repo. CI will build and push the new image!


### PR DESCRIPTION
We build and publish container images for both AMD and ARM but the base image we use in the `Dockerfile` is AMD only breaking the ARM runtime.

This PR should fix the ARM runtime issues (tested locally on Apple M1)